### PR TITLE
Pages: починить добавление блока

### DIFF
--- a/components/ContentEditor/Editor/EditorSample.tsx
+++ b/components/ContentEditor/Editor/EditorSample.tsx
@@ -63,6 +63,7 @@ const EditorSample: React.FC<EditorT> = (props) => {
           </Tooltip>
 
           <CreationMenu
+            index={index}
             anchorEl={addAnchorEl}
             setEditors={setEditors}
             closeMenu={() => setAddAnchorEl(null)}

--- a/components/ContentEditor/Menus/CreationMenu.tsx
+++ b/components/ContentEditor/Menus/CreationMenu.tsx
@@ -6,13 +6,14 @@ import { EditorsT } from 'kit/Editor/ContentEditor';
 import CreationMenuItem from './MenuItem/CreationMenuItem';
 
 type NewItemMenuProps = {
+  index: number;
   closeMenu: () => void;
   anchorEl: Element | null;
   setEditors: React.Dispatch<React.SetStateAction<EditorsT[]>>;
 };
 
 const CreationMenu: React.FC<NewItemMenuProps> = (props) => {
-  const { anchorEl, closeMenu, setEditors } = props;
+  const { index, anchorEl, closeMenu, setEditors } = props;
 
   return (
     <Menu
@@ -26,7 +27,13 @@ const CreationMenu: React.FC<NewItemMenuProps> = (props) => {
       sx={menuStyles}
     >
       {CreationMenuConfig.map((elem, i) => (
-        <CreationMenuItem key={i} elem={elem} closeMenu={closeMenu} setEditors={setEditors} />
+        <CreationMenuItem
+          key={i}
+          index={index}
+          elem={elem}
+          closeMenu={closeMenu}
+          setEditors={setEditors}
+        />
       ))}
     </Menu>
   );

--- a/components/ContentEditor/Menus/MenuItem/CreationMenuItem.tsx
+++ b/components/ContentEditor/Menus/MenuItem/CreationMenuItem.tsx
@@ -7,6 +7,7 @@ import { EditorsT } from 'kit/Editor/ContentEditor';
 import { Type } from 'kit/Editor/common/withListsPlugin';
 
 type MenuElementT = {
+  index: number;
   closeMenu: () => void;
   elem: CreationMenuConfigT;
   onClick?: (type: Type) => void;
@@ -15,6 +16,7 @@ type MenuElementT = {
 
 const CreationMenuItem: React.FC<MenuElementT> = (props) => {
   const {
+    index,
     onClick,
     closeMenu,
     setEditors,
@@ -26,7 +28,11 @@ const CreationMenuItem: React.FC<MenuElementT> = (props) => {
     if (onClick) onClick(type);
 
     closeMenu();
-    setEditors((editors) => [...editors, editorExample(type)]);
+    setEditors((editors) => {
+      const newEditors = [...editors];
+      newEditors.splice(index + 1, 0, editorExample(type));
+      return newEditors;
+    });
   };
 
   return (


### PR DESCRIPTION
Прямо сейчас в редакторе https://app.xieffect.ru/community/15/page/5 Editor новые блоки при создании их через плюсик добавляются в конец.

Нужно сделать так, чтобы блок добавлялся после того блока на котором был нажат плюс
![1](https://user-images.githubusercontent.com/103072626/201523453-51b1f051-fba0-4331-a8e3-8f76aecdfda4.JPG)
![2](https://user-images.githubusercontent.com/103072626/201523457-d8c77200-55cb-441e-8c17-2cb32b26b939.JPG)
![3](https://user-images.githubusercontent.com/103072626/201523462-188f7177-dd33-46e0-b1ef-487b17474111.JPG)
